### PR TITLE
[Ricardo Alves] [Project Starwars Datatable Hooks]

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,27 +1,14 @@
 import React from 'react';
-import logo from './logo.svg';
-import './App.css';
+import PlanetsProvider from './context/PlanetsProvider';
+import Table from './components/Table';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={ logo } className="App-logo" alt="logo" />
-        <p>
-          Edit
-          <code>src/App.js</code>
-          and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <main>
+      <PlanetsProvider>
+        <Table />
+      </PlanetsProvider>
+    </main>
   );
 }
 

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,0 +1,14 @@
+import React, { useContext, useEffect } from 'react';
+import PlanetsContext from '../context/PlanetsContext';
+
+function Table() {
+  const { planets, setPlanets } = useContext(PlanetsContext);
+  useEffect(() => setPlanets('XABLAU USING EFFECT'));
+  return (
+    <div>
+      { planets }
+    </div>
+  );
+}
+
+export default Table;

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,12 +1,55 @@
 import React, { useContext, useEffect } from 'react';
 import PlanetsContext from '../context/PlanetsContext';
+import fetchPlanets from '../services';
 
 function Table() {
   const { planets, setPlanets } = useContext(PlanetsContext);
-  useEffect(() => setPlanets('XABLAU USING EFFECT'));
+  const headers = [
+    'Name',
+    'Rotation Period',
+    'Orbital Period',
+    'Diameter',
+    'Climate',
+    'Gravity',
+    'Terrain',
+    'Surface Water',
+    'Population',
+    'Films',
+    'Created',
+    'Edited',
+    'URL',
+  ];
+  useEffect(() => {
+    fetchPlanets(setPlanets);
+  }, [setPlanets]);
   return (
     <div>
-      { planets }
+      {planets.results
+        ? (
+          <table>
+            <tr>
+              {headers.map((header) => <th key={ header }>{ header }</th>)}
+            </tr>
+            {planets.results.map((result) => (
+              <tr key={ result.name }>
+                <td key={ result.name }>{ result.name }</td>
+                <td key={ result.rotation_period }>{ result.rotation_period }</td>
+                <td key={ result.orbital_period }>{ result.orbital_period }</td>
+                <td key={ result.diameter }>{ result.diameter }</td>
+                <td key={ result.climate }>{ result.climate }</td>
+                <td key={ result.gravity }>{ result.gravity }</td>
+                <td key={ result.terrain }>{ result.terrain }</td>
+                <td key={ result.surface_water }>{ result.surface_water }</td>
+                <td key={ result.population }>{ result.population }</td>
+                <td key={ result.films }>{ result.films }</td>
+                <td key={ result.created }>{ result.created }</td>
+                <td key={ result.edited }>{ result.edited }</td>
+                <td key={ result.url }>{ result.url }</td>
+              </tr>
+            ))}
+          </table>
+        )
+        : 'Loading...' }
     </div>
   );
 }

--- a/src/context/PlanetsContext.js
+++ b/src/context/PlanetsContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const PlanetsContext = createContext();
+
+export default PlanetsContext;

--- a/src/context/PlanetsProvider.js
+++ b/src/context/PlanetsProvider.js
@@ -3,8 +3,7 @@ import React, { useState } from 'react';
 import PlanetsContext from './PlanetsContext';
 
 function PlanetsProvider({ children }) {
-  const [planets, setPlanets] = useState('XABLAU');
-
+  const [planets, setPlanets] = useState({});
   return (
     <main>
       <PlanetsContext.Provider value={ { planets, setPlanets } }>

--- a/src/context/PlanetsProvider.js
+++ b/src/context/PlanetsProvider.js
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import PlanetsContext from './PlanetsContext';
+
+function PlanetsProvider({ children }) {
+  const [planets, setPlanets] = useState('XABLAU');
+
+  return (
+    <main>
+      <PlanetsContext.Provider value={ { planets, setPlanets } }>
+        { children }
+      </PlanetsContext.Provider>
+    </main>
+  );
+}
+
+PlanetsProvider.propTypes = {
+  children: PropTypes.element.isRequired,
+};
+
+export default PlanetsProvider;

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,0 +1,8 @@
+async function fetchPlanets(hook) {
+  const url = 'https://swapi-trybe.herokuapp.com/api/planets/';
+  const response = await fetch(url);
+  const data = await response.json();
+  hook(data);
+}
+
+export default fetchPlanets;


### PR DESCRIPTION
- [x] 1) Faça uma requisição para o endpoint `/planets` da API de Star Wars e preencha uma tabela com os dados retornados, com exceção dos da coluna `residents`
- [ ] 2) Filtre a tabela através de um texto, inserido num *campo de texto*, exibindo somente os planetas cujos nomes incluam o texto digitado
- [ ] 3) Crie um filtro para valores numéricos
- [ ] 4) Não utilize filtros repetidos
- [ ] 5) Apague o filtro de valores numéricos e desfaça as filtragens dos dados da tabela ao clicar no ícone de `X` de um dos filtro
### BÔNUS
- [ ] 6) Ordene as colunas de forma ascendente ou descendente